### PR TITLE
Add fix for the ControlsystemAdapter-OPC-UA history test.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,7 @@ include(ExternalProject)
   #"-DUA_ENABLE_ENABLE_MULTITHREADING=ON"
    PATCH_COMMAND git apply ${PROJECT_SOURCE_DIR}/cmakefile.patch
                            ${PROJECT_SOURCE_DIR}/FixForZeroSamplingInterval.patch
+                           ${PROJECT_SOURCE_DIR}/SkipFirstHistoryEntry.patch
    UPDATE_COMMAND bash -c ${UPDATESTRING}
   )
 

--- a/SkipFirstHistoryEntry.patch
+++ b/SkipFirstHistoryEntry.patch
@@ -1,0 +1,22 @@
+diff --git a/plugins/historydata/ua_history_data_backend_memory.c b/plugins/historydata/ua_history_data_backend_memory.c
+index 744216386..7df19b1b9 100644
+--- a/plugins/historydata/ua_history_data_backend_memory.c
++++ b/plugins/historydata/ua_history_data_backend_memory.c
+@@ -205,9 +205,17 @@ serverSetHistoryData_backend_memory(UA_Server *server,
+     }
+     UA_DateTime timestamp = 0;
+     if (value->hasSourceTimestamp) {
++      if(value->sourceTimestamp == 116444736000000000) {
++        return UA_STATUSCODE_GOOD;
++      } else {
+         timestamp = value->sourceTimestamp;
++      }
+     } else if (value->hasServerTimestamp) {
++      if(value->serverTimestamp == 116444736000000000) {
++        return UA_STATUSCODE_GOOD;
++      } else {
+         timestamp = value->serverTimestamp;
++      }
+     } else {
+         timestamp = UA_DateTime_now();
+     }


### PR DESCRIPTION
When adding the subscription for the history an initial value is returned that is filled to the history. This happens before the control system adapter is started and the source time stamp is set to 01.01.1970. If exactly this timestamp is passed to the history plugin filling the history is skipped.