### PR TITLE
Remove python dependency.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ SET(${PROJECT_NAME}_MAJOR_VERSION 1)
 SET(${PROJECT_NAME}_MINOR_VERSION 3)
 SET(${PROJECT_NAME}_PATCH_VERSION 3)
 include(${CMAKE_SOURCE_DIR}/cmake/set_version_numbers.cmake)
-set(${PROJECT_NAME}_REVISION 6)
+set(${PROJECT_NAME}_REVISION 7)
 message(STATUS "Version number: ${${PROJECT_NAME}_FULL_LIBRARY_VERSION}")
 
 if(${CMAKE_VERSION} VERSION_LESS "3.18.0") 
@@ -41,6 +41,7 @@ include(ExternalProject)
    PATCH_COMMAND git apply ${PROJECT_SOURCE_DIR}/cmakefile.patch
                            ${PROJECT_SOURCE_DIR}/FixForZeroSamplingInterval.patch
                            ${PROJECT_SOURCE_DIR}/SkipFirstHistoryEntry.patch
+                           ${PROJECT_SOURCE_DIR}/RemovePythonDependency.patch
    UPDATE_COMMAND bash -c ${UPDATESTRING}
   )
 

--- a/RemovePythonDependency.patch
+++ b/RemovePythonDependency.patch
@@ -1,0 +1,13 @@
+diff --git a/tools/cmake/open62541Config.cmake.in b/tools/cmake/open62541Config.cmake.in
+index 0c2544ccb..59e7c933b 100644
+--- a/tools/cmake/open62541Config.cmake.in
++++ b/tools/cmake/open62541Config.cmake.in
+@@ -6,7 +6,7 @@ set (open62541_TOOLS_DIR @PACKAGE_open62541_install_tools_dir@ CACHE PATH "Path
+ set (open62541_NODESET_DIR @PACKAGE_open62541_install_nodeset_dir@ CACHE PATH "Path to the directory that contains the OPC UA schema repository")
+ 
+ include(CMakeFindDependencyMacro)
+-find_dependency(PythonInterp REQUIRED)
++#find_dependency(PythonInterp REQUIRED)
+ 
+ include("${CMAKE_CURRENT_LIST_DIR}/open62541Macros.cmake")
+ 


### PR DESCRIPTION
This avoids cmake problems with building the debian packages. Else one would have to add a dependency to python3-dev, which is basically not needed.