### PR TITLE
fix relocatable cmake-config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,9 @@ include(ExternalProject)
 install(DIRECTORY ${CMAKE_BINARY_DIR}/open62541_install/include/ DESTINATION include)
 # this defines architecture-dependent ${CMAKE_INSTALL_LIBDIR}
 include(GNUInstallDirs)
+# unfortunately, when  ${CMAKE_INSTALL_LIBDIR} evaluates to lib/<multiarch-tuple>, e.g. lib/x86_64-linux-gnu, the
+# last path part breaks relocatable cmake-config. So need to remove it.
+STRING(REGEX REPLACE "/.*$" "" CMAKE_INSTALL_LIBDIR ${CMAKE_INSTALL_LIBDIR})
 # source lib dir is also architecture-dependent, sometimes called lib64
 install(DIRECTORY ${CMAKE_BINARY_DIR}/open62541_install/lib/ OPTIONAL DESTINATION ${CMAKE_INSTALL_LIBDIR} )
 install(DIRECTORY ${CMAKE_BINARY_DIR}/open62541_install/lib64/ OPTIONAL DESTINATION ${CMAKE_INSTALL_LIBDIR} )


### PR DESCRIPTION
in case ${CMAKE_INSTALL_LIBDIR} evaluates to lib/<multiarch-tuple>


This should fix following error in downstream projects:
CMake Error at /usr/lib/x86_64-linux-gnu/cmake/open62541/open62541Targets.cmake:80 (message):
  The imported target "open62541::open62541" references the file

     "/usr/lib/lib/libopen62541.so.1.3.3-8"

  but this file does not exist.  Possible reasons include:

  * The file was deleted, renamed, or moved to another location.

  * An install or uninstall procedure did not complete successfully.

  * The installation package was faulty and contained

     "/usr/lib/x86_64-linux-gnu/cmake/open62541/open62541Targets.cmake"

  but not all the files it references.
  
  Full log:
  https://jenkins.msktools.desy.de/sw/job/ChimeraTK/job/fasttrack/job/ControlSystemAdapter-OPC-UA-Adapter/job/master/448/console
