### PR TITLE
Add automatic search for MBEDTSL.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ ExternalProject_Add(external-open62541
  #"-DUA_ENABLE_ENABLE_MULTITHREADING=ON"
   PATCH_COMMAND git apply ${PROJECT_SOURCE_DIR}/cmakefile.patch
                           ${PROJECT_SOURCE_DIR}/SkipFirstHistoryEntry.patch
+                          ${PROJECT_SOURCE_DIR}/config.patch
   UPDATE_COMMAND bash -c ${UPDATESTRING}
   # setting -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX} works in principle and the temporary install to ${CMAKE_BINARY_DIR}/open62541_install
   # is not required. 

--- a/config.patch
+++ b/config.patch
@@ -1,0 +1,12 @@
+diff --git a/tools/cmake/open62541Config.cmake.in b/tools/cmake/open62541Config.cmake.in
+index 1197e4498..77b3959e2 100644
+--- a/tools/cmake/open62541Config.cmake.in
++++ b/tools/cmake/open62541Config.cmake.in
+@@ -1,2 +1,6 @@
+ @PACKAGE_INIT@
+ include("${CMAKE_CURRENT_LIST_DIR}/open62541Targets.cmake")
++
++# find_dependency has no option to provide hints for modules, so temporary add the path to CMAKE_MODULE_PATH
++list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
++find_dependency(MbedTLS REQUIRED)
+\ No newline at end of file


### PR DESCRIPTION
Without projects using the stack fail because of the exported dependencies to MBEDTSL.